### PR TITLE
Adds ability to change which mission is tracked

### DIFF
--- a/src/main/java/com/arrested/lbmmo/persistence/entity/QuestInProgress.java
+++ b/src/main/java/com/arrested/lbmmo/persistence/entity/QuestInProgress.java
@@ -62,6 +62,10 @@ public class QuestInProgress {
 		return tracked;
 	}
 	
+	public void isTracked(boolean tracked) {
+		this.tracked = tracked;
+	}
+	
 	public Objective getCurrentObjective() {
 		
 		for (Objective objective : quest.getObjectives()) {

--- a/src/main/java/com/arrested/lbmmo/ws/controller/QuestLogController.java
+++ b/src/main/java/com/arrested/lbmmo/ws/controller/QuestLogController.java
@@ -120,6 +120,12 @@ public class QuestLogController extends AbstractServiceController {
 		return questToAdd.getName() + " added to mission log";
 	}
 
+	@RequestMapping(value = "track-quest/{questId}", method = RequestMethod.PUT)
+	public String trackQuest(@PathVariable String questId) {
+		
+		return "";
+	}
+	
 	private Set<Quest> findAvailableQuests(Character character) {
 
 		Set<QuestInProgress> inProgress = character.getQuestsInProgress();

--- a/src/main/java/com/arrested/lbmmo/ws/controller/QuestLogController.java
+++ b/src/main/java/com/arrested/lbmmo/ws/controller/QuestLogController.java
@@ -121,9 +121,36 @@ public class QuestLogController extends AbstractServiceController {
 	}
 
 	@RequestMapping(value = "track-quest/{questId}", method = RequestMethod.PUT)
-	public String trackQuest(@PathVariable String questId) {
+	public void trackQuest(@PathVariable String questId) {
 		
-		return "";
+		Character character = getServiceUser().getLoggedInCharacter();
+		QuestInProgress newlyTrackedQip = null;
+		long id = -1;
+		
+		try {
+			id = Long.parseLong(questId);
+		} catch (NumberFormatException e) {
+			
+		}
+		
+		for (QuestInProgress qip : character.getQuestsInProgress()) {
+			if ( id == qip.getQuest().getId()) {
+				newlyTrackedQip = qip;
+			}
+		}
+		
+		if (newlyTrackedQip != null) {
+			
+			QuestInProgress oldTrackedQip = character.getTrackedQuestInProgress();
+			
+			if (oldTrackedQip != null) {
+				oldTrackedQip.isTracked(false);
+				questInProgressRepo.save(oldTrackedQip);
+			}
+			
+			newlyTrackedQip.isTracked(true);
+			questInProgressRepo.save(newlyTrackedQip);
+		}
 	}
 	
 	private Set<Quest> findAvailableQuests(Character character) {
@@ -177,8 +204,7 @@ public class QuestLogController extends AbstractServiceController {
 
 			if (objective.getQuestStep() == 0) {
 				locationBean.setLatitude(objective.getWaypoint().getLatitude());
-				locationBean.setLongitude(objective.getWaypoint()
-						.getLongitude());
+				locationBean.setLongitude(objective.getWaypoint().getLongitude());
 			}
 		}
 
@@ -187,8 +213,7 @@ public class QuestLogController extends AbstractServiceController {
 		return questBean;
 	}
 
-	private QuestInProgress populateQuestInProgress(Quest quest,
-			Character character) {
+	private QuestInProgress populateQuestInProgress(Quest quest, Character character) {
 
 		QuestInProgress qip = new QuestInProgress();
 		qip.setQuest(quest);

--- a/src/main/resources/META-INF/resources/js/mapControls.js
+++ b/src/main/resources/META-INF/resources/js/mapControls.js
@@ -73,6 +73,10 @@ function pinNextObjective(data) {
 		
 		pinnedQuest = data.questName;
 		
+		if ($("#pinnedQuest")) {
+			updatePinnedMission();
+		}
+		
 	} else {
 		// TODO: Remove nextObjective marker
 	}
@@ -101,13 +105,17 @@ function parseInactiveQuests(data) {
 	
 	if (data.length) {
 		data.forEach(function(element, index) {
-			content = content + "<div>" + element.questName + "</div>";
+			content = content + "<div data-quest-id='"+ element.questId +"' class='inactiveQuest'>" + element.questName + "</div>";
 		});
 	} else {
 		content = "No inactive missions";
 	}
 	
 	inactiveQuests = content;
+	
+	if ($("#inactiveQuests")) {
+		updateInactiveMissions();
+	}
 }
 
 // Controls ///////////////////////////////////////////////////////////////////
@@ -129,6 +137,18 @@ function showAvailableUpdated() {
 		clearMarkers(availableQuestMarkers);
 		availableQuestMarkers = [];
 	}
+}
+
+function trackMission() {
+	
+	$.ajax({
+		type: "PUT",
+		url : questLogUrl + "track-quest/" + this.dataset.questId + "/",
+		success: function() {
+			readQuestObjectives();
+			readInactiveQuests();
+		}
+	});
 }
 
 // Periodic update functions //////////////////////////////////////////////////
@@ -177,8 +197,8 @@ function showPosition(position) {
 
 		google.maps.event.addListener(youAreHereMarker, 'click', function() {
 		    questLog.open(map, youAreHereMarker);
-		    $("#pinnedQuest").html(pinnedQuest);
-		    $("#inactiveQuests").html(inactiveQuests);
+		    updatePinnedMission();
+		    updateInactiveMissions();
 		    $("#showAvailable").change(showAvailableUpdated);
 		});
 		
@@ -215,6 +235,15 @@ function addAvailableQuestClickListener(marker, quest) {
 			});
 		});
 	});
+}
+
+function updatePinnedMission() {
+	$("#pinnedQuest").html(pinnedQuest)
+}
+
+function updateInactiveMissions() {
+	$("#inactiveQuests").html(inactiveQuests);
+    $("#inactiveQuests .inactiveQuest").click(trackMission);
 }
 
 function clearMarkers(markers) {

--- a/src/test/java/com/arrested/lbmmo/ws/controller/QuestLogControllerTest.java
+++ b/src/test/java/com/arrested/lbmmo/ws/controller/QuestLogControllerTest.java
@@ -145,4 +145,27 @@ public class QuestLogControllerTest extends AbstractMockedActiveUserServiceTest 
 		
 		Assert.assertEquals("This mission is not currently available to you", controller.acceptQuest("6"));
 	}
+	
+	@Test
+	public void trackQuestTest_smokeTest() {
+		
+		controller.trackQuest("2");
+		
+		Assert.assertEquals(2, character.getTrackedQuestInProgress().getId());
+	}
+	
+	@Test
+	public void trackQuestTest_clearExistingTrackedQuest() {
+
+		controller.trackQuest("2");
+		controller.trackQuest("3");
+		
+		Assert.assertEquals(3, character.getTrackedQuestInProgress().getId());
+		
+		for (QuestInProgress qip : character.getQuestsInProgress()) {
+			if (3 != qip.getId()) {
+				Assert.assertFalse(qip.isTracked());
+			}
+		}
+	}
 }

--- a/src/test/java/com/arrested/lbmmo/ws/controller/QuestLogControllerTest.java
+++ b/src/test/java/com/arrested/lbmmo/ws/controller/QuestLogControllerTest.java
@@ -75,7 +75,7 @@ public class QuestLogControllerTest extends AbstractMockedActiveUserServiceTest 
 	@Test
 	public void getInactiveQuestsTest() {
 		
-		addQuestToQuestsInProgress(character);
+		addQuestToQuestsInProgress(character, 0l);
 		
 		Assert.assertEquals(1, controller.getInactiveQuests().size());
 	}
@@ -83,18 +83,9 @@ public class QuestLogControllerTest extends AbstractMockedActiveUserServiceTest 
 	@Test
 	public void getAvailableQuestsTest() {
 		
-		addQuestToQuestsInProgress(character);
+		addQuestToQuestsInProgress(character, 0l);
 		
 		Assert.assertEquals("Proper number of quests", QUESTS_IN_LOG - 1, controller.getAvailableQuests().size());
-	}
-	
-	private void addQuestToQuestsInProgress(Character character) {
-		
-		QuestInProgress qip = new QuestInProgress();
-		qip.setQuest(questRepo.findOne(0l));
-		qip.setCurrentStep(0);
-		
-		character.getQuestsInProgress().add(qip);
 	}
 	
 	@Test
@@ -149,23 +140,48 @@ public class QuestLogControllerTest extends AbstractMockedActiveUserServiceTest 
 	@Test
 	public void trackQuestTest_smokeTest() {
 		
+		addQuestToQuestsInProgress(character, 2l);
+		
 		controller.trackQuest("2");
 		
-		Assert.assertEquals(2, character.getTrackedQuestInProgress().getId());
+		Assert.assertEquals(2, character.getTrackedQuestInProgress().getQuest().getId());
 	}
 	
 	@Test
 	public void trackQuestTest_clearExistingTrackedQuest() {
 
+		addQuestToQuestsInProgress(character, 2l);
+		addQuestToQuestsInProgress(character, 3l);
+		
 		controller.trackQuest("2");
 		controller.trackQuest("3");
 		
-		Assert.assertEquals(3, character.getTrackedQuestInProgress().getId());
+		Assert.assertEquals(3, character.getTrackedQuestInProgress().getQuest().getId());
 		
 		for (QuestInProgress qip : character.getQuestsInProgress()) {
-			if (3 != qip.getId()) {
+			if (3 != qip.getQuest().getId()) {
 				Assert.assertFalse(qip.isTracked());
 			}
 		}
+	}
+	
+	@Test
+	public void trackQuestTest_invalidNewTrackedQuest() {
+		
+		addQuestToQuestsInProgress(character, 2l);
+		
+		controller.trackQuest("2");
+		controller.trackQuest("100");
+		
+		Assert.assertEquals(2, character.getTrackedQuestInProgress().getQuest().getId());
+	}
+	
+	private void addQuestToQuestsInProgress(Character character, long questId) {
+		
+		QuestInProgress qip = new QuestInProgress();
+		qip.setQuest(questRepo.findOne(questId));
+		qip.setCurrentStep(0);
+		
+		character.getQuestsInProgress().add(qip);
 	}
 }


### PR DESCRIPTION
Backed changes:
- [x] Service allows to track a mission
- [x] Tracking a new mission removes the tracked flag from the currently tracked mission, if one is tracked

Client changes:
- [x] Add a "track" button to the inactive missions section
- [x] Clicking the "track" button triggers a call to the service
- [x] Refresh the mission log
