### PR TITLE
Update current objective

### DIFF
--- a/src/main/java/com/arrested/lbmmo/ws/bean/response/EncounterBean.java
+++ b/src/main/java/com/arrested/lbmmo/ws/bean/response/EncounterBean.java
@@ -11,9 +11,12 @@ public class EncounterBean {
 	
 	private boolean combatEncounter;
 
+	private boolean trackedObjectiveUpdated;
+	
 	public EncounterBean() {
 		messages = new ArrayList<String>();
 		combatEncounter = false;
+		trackedObjectiveUpdated = false;
 	}
 	
 	public List<String> getMessages() {
@@ -30,6 +33,14 @@ public class EncounterBean {
 
 	public void setCombatEncounter(boolean combatEncounter) {
 		this.combatEncounter = combatEncounter;
+	}
+	
+	public boolean isTrackedObjectiveUpdated() {
+		return trackedObjectiveUpdated;
+	}
+	
+	public void setTrackedObjectiveUpdated(boolean objectiveUpdated) {
+		this.trackedObjectiveUpdated = objectiveUpdated;
 	}
 	
 	public double getMetersToNextObjective() {

--- a/src/main/java/com/arrested/lbmmo/ws/controller/MapController.java
+++ b/src/main/java/com/arrested/lbmmo/ws/controller/MapController.java
@@ -32,11 +32,9 @@ public class MapController extends AbstractServiceController {
 		EncounterBean encounter = new EncounterBean();
 		Character character = getServiceUser().getLoggedInCharacter();
 		
-		if (character == null || character.getTrackedQuestInProgress() == null) {
+		if (character == null) {
 			return encounter;
 		}
-		
-		double distance = distanceService.distanceToObjective(position, character.getTrackedQuestInProgress().getCurrentObjective());
 		
 		for (QuestInProgress qip : character.getQuestsInProgress()) {
 			Objective objective = qip.getCurrentObjective();
@@ -44,10 +42,17 @@ public class MapController extends AbstractServiceController {
 				encounter.getMessages().add("Updating " + objective.getQuest().getName());
 				qip.setCurrentStep(qip.getCurrentStep()+1);
 				qipRepo.save(qip);
+				
+				if (qip.isTracked()) {
+					encounter.setTrackedObjectiveUpdated(true);
+				}
 			}
 		}
 		
-		encounter.setMetersToNextObjective(distance);
+		if (character.getTrackedQuestInProgress() != null) {
+			encounter.setMetersToNextObjective(distanceService.distanceToObjective(position, character.getTrackedQuestInProgress().getCurrentObjective()));
+		}
+		
 		encounter.setCombatEncounter(false);
 
 		return encounter;

--- a/src/main/resources/META-INF/resources/js/mapControls.js
+++ b/src/main/resources/META-INF/resources/js/mapControls.js
@@ -131,6 +131,11 @@ function parseInactiveQuests(data) {
 }
 
 function processEvent(data) {
+
+	if (data.trackedObjectiveUpdated) {
+		readQuestObjectives();
+	}
+
 	if (data.messages) {
 		data.messages.forEach(
 				function(currentValue) {

--- a/src/main/resources/META-INF/resources/js/mapControls.js
+++ b/src/main/resources/META-INF/resources/js/mapControls.js
@@ -41,6 +41,7 @@ $(document).ready(function() {
 	readInactiveQuests();
 
 	window.setInterval(sendLocationToServer, 4500);
+	window.setInterval(readQuestObjectives, 60 * 1000);
 
 	$.get('/ui-elements/questLog.html').then(function(responseData) {
 		questLog = new google.maps.InfoWindow({


### PR DESCRIPTION
Fixes #38.
- [x] Server should provide a flag to client to signify that the tracked objective was updated
- [x] Client should immediately update current objective if this flag is received
- [x] Client should periodically update the current objective even if this flag is not received 
