### PR TITLE
Complete quests excluded from service responses

### DIFF
--- a/src/main/java/com/arrested/lbmmo/persistence/entity/Character.java
+++ b/src/main/java/com/arrested/lbmmo/persistence/entity/Character.java
@@ -45,6 +45,10 @@ public class Character {
 		loggedIn = false;
 	}
 	
+	public long getId() {
+		return this.id;
+	}
+	
 	public String getName() {
 		return this.name;
 	}

--- a/src/main/java/com/arrested/lbmmo/persistence/repository/QuestInProgressRepository.java
+++ b/src/main/java/com/arrested/lbmmo/persistence/repository/QuestInProgressRepository.java
@@ -1,9 +1,17 @@
 package com.arrested.lbmmo.persistence.repository;
 
+import java.util.Set;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.arrested.lbmmo.persistence.entity.QuestInProgress;
 
 public interface QuestInProgressRepository extends JpaRepository<QuestInProgress,Long>{
 
+	@Query(value="select * from quest_in_progress where completed_date is null and character_id = ?1", nativeQuery=true)
+	public Set<QuestInProgress> findIncompleteMissions(long characterId);
+	
+	@Query(value="select * from quest_in_progress where completed_date is not null and character_id = ?1", nativeQuery=true)
+	public Set<QuestInProgress> findCompleteMissions(long characterId);
 }

--- a/src/main/java/com/arrested/lbmmo/ws/controller/QuestLogController.java
+++ b/src/main/java/com/arrested/lbmmo/ws/controller/QuestLogController.java
@@ -55,7 +55,7 @@ public class QuestLogController extends AbstractServiceController {
 		Set<QuestBean> quests = new HashSet<QuestBean>();
 
 		if (character != null) {
-			for (QuestInProgress qip : character.getQuestsInProgress()) {
+			for (QuestInProgress qip : questInProgressRepo.findIncompleteMissions(character.getId())) {
 				if (trackedQuest == null || trackedQuest.getId() != qip.getId()) {
 					quests.add(populateQuestBean(qip));
 				}

--- a/src/test/java/com/arrested/lbmmo/ws/controller/QuestLogControllerTest.java
+++ b/src/test/java/com/arrested/lbmmo/ws/controller/QuestLogControllerTest.java
@@ -194,5 +194,7 @@ public class QuestLogControllerTest extends AbstractMockedActiveUserServiceTest 
 		qip.setCurrentStep(0);
 		
 		character.getQuestsInProgress().add(qip);
+		
+		Mockito.when(this.questInProgressRepo.findIncompleteMissions(character.getId())).thenReturn(character.getQuestsInProgress());
 	}
 }


### PR DESCRIPTION
The response from get inactive quests only has incomplete quests.

Fixes #55.
