### PR TITLE
Adds a logback config file with more reasonable log levels

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,8 +7,8 @@
   </appender>
 
   <logger name="com.arrested" level="info" additivity="false">
-		<appender-ref ref="STDOUT" />
-	</logger>
+    <appender-ref ref="STDOUT" />
+  </logger>
 
   <root level="warn">
     <appender-ref ref="STDOUT"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.arrested" level="info" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+  <root level="warn">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
The default root logger in logback logs at `DEBUG` severity, creating some impressive log spam.
